### PR TITLE
Implemented the _find query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 sudo: required
 dist: trusty
 before_install:
- - ./couchdb2.0-install.sh
+ - ./couchdb2.1-install.sh
 before_script:
  - curl -X PUT http://127.0.0.1:5984/_config/admins/adminuser -d '"password"'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 before_install:
  - ./couchdb2.1-install.sh
 before_script:
- - curl -X PUT http://127.0.0.1:5984/_config/admins/adminuser -d '"password"'
+ - curl -X PUT http://127.0.0.1:5984/_node/couchdb@localhost/_config/admins/adminuser -d '"password"'
 script:
  - go get github.com/twinj/uuid
  - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 go:
  - 1.5
  - 1.6
+sudo: required
+dist: trusty
 before_install:
  - ./couchdb2.0-install.sh
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: go
 go:
  - 1.5
  - 1.6
-services:
- - couchdb
+before_install:
+ - ./couchdb2.0-install.sh
 before_script:
- - curl -X PUT http://127.0.0.1:5984/_config/admins/adminuser -d '"password"' 
+ - curl -X PUT http://127.0.0.1:5984/_config/admins/adminuser -d '"password"'
 script:
  - go get github.com/twinj/uuid
  - go test -v ./...

--- a/couchdb2.0-install.sh
+++ b/couchdb2.0-install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mkdir temp
+cd temp
+wget https://raw.githubusercontent.com/afiskon/install-couchdb/master/install-couchdb.sh
+sh install-couchdb.sh

--- a/couchdb2.0-install.sh
+++ b/couchdb2.0-install.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-mkdir temp
-cd temp
-wget https://raw.githubusercontent.com/afiskon/install-couchdb/master/install-couchdb.sh
-sh install-couchdb.sh

--- a/couchdb2.1-install.sh
+++ b/couchdb2.1-install.sh
@@ -1,10 +1,24 @@
 #!/bin/sh
 
-echo "deb https://apache.bintray.com/couchdb-deb trusty main" \
-| sudo tee -a /etc/apt/sources.list
+set -ex
 
-curl -L https://couchdb.apache.org/repo/bintray-pubkey.asc \
-    | sudo apt-key add -
+sudo apt-get --no-install-recommends -y install \
+    build-essential pkg-config erlang \
+    libicu-dev libmozjs185-dev libcurl4-openssl-dev
 
-sudo apt-get update || true
-sudo apt-get --no-install-recommends -y install couchdb
+mkdir temp
+cd temp
+
+wget http://www.trieuvan.com/apache/couchdb/source/2.1.0/apache-couchdb-2.1.0.tar.gz
+
+tar -xf apache-couchdb-2.1.0.tar.gz
+cd apache-couchdb-2.1.0.tar.gz
+./configure
+make release
+nohup ./rel/couchdb/bin/couchdb > /dev/null &
+
+curl -X PUT http://127.0.0.1:5984/_users
+
+curl -X PUT http://127.0.0.1:5984/_replicator
+
+

--- a/couchdb2.1-install.sh
+++ b/couchdb2.1-install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "deb https://apache.bintray.com/couchdb-deb trusty main" \
+| sudo tee -a /etc/apt/sources.list
+
+curl -L https://couchdb.apache.org/repo/bintray-pubkey.asc \
+    | sudo apt-key add -
+
+sudo apt-get update || true
+sudo apt-get --no-install-recommends -y install couchdb

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -3,7 +3,7 @@ package couchdb_test
 import (
 	"bytes"
 	//"encoding/json"
-	"github.com/rhinoman/couchdb-go"
+	"github.com/fjace05/couchdb-go"
 	"github.com/twinj/uuid"
 	"io/ioutil"
 	"math/rand"


### PR DESCRIPTION
I've implemented the _find query trying to keep it semi-consistent to a call to GetView method. A new struct type was added that includes the available parameters that are required and optional for the _find query. Since this api endpoint is a POST request simply using the url.Values of the View api doesn't work. A few of the parameters can be JSON objects so they are left as interface types and users should be careful to make sure they set them to something Marshalable.

I've also added a super simple test to make sure the new feature works. 